### PR TITLE
feat: Update chrome-devtools skill to persist browser sessions

### DIFF
--- a/.claude/skills/chrome-devtools/.gitignore
+++ b/.claude/skills/chrome-devtools/.gitignore
@@ -1,0 +1,1 @@
+.browser-endpoint

--- a/.claude/skills/chrome-devtools/scripts/PERSISTENT-BROWSER.md
+++ b/.claude/skills/chrome-devtools/scripts/PERSISTENT-BROWSER.md
@@ -1,0 +1,107 @@
+# Persistent Browser Mode
+
+These scripts enable you to launch Chrome once and keep it open for multiple commands, making it easier to interact with authenticated sessions and multi-step workflows.
+
+## Quick Start
+
+### 1. Launch Persistent Browser
+
+```bash
+# Launch browser (visible window)
+node launch-persistent.js --headless=false
+
+# Launch with initial URL
+node launch-persistent.js --headless=false --url=https://example.com/login
+
+# Launch headless
+node launch-persistent.js
+```
+
+The browser will stay open and print a message confirming it's ready.
+
+### 2. Run Commands
+
+All existing scripts will automatically connect to the persistent browser:
+
+```bash
+# Navigate to a page
+node navigate.js --url https://example.com/dashboard
+
+# Take a screenshot
+node screenshot.js --output ./screenshot.png
+
+# Run JavaScript
+node evaluate.js --script "document.title"
+
+# Get page snapshot
+node snapshot.js
+
+# Fill forms
+node fill.js --selector "#username" --value "user@example.com"
+node click.js --selector "button[type=submit]"
+```
+
+### 3. Close Browser
+
+```bash
+# Close the persistent browser
+node close-persistent.js
+
+# Or press Ctrl+C in the launch-persistent.js terminal
+```
+
+## How It Works
+
+1. **launch-persistent.js** starts Chrome with remote debugging enabled and saves the WebSocket endpoint to `.browser-endpoint`
+2. All other scripts check for this file first and connect to the existing browser if found
+3. If no persistent browser exists, scripts fall back to launching their own temporary browser (original behavior)
+
+## Use Cases
+
+### Authenticated Sessions
+```bash
+# Launch browser
+node launch-persistent.js --headless=false --url=https://app.example.com/login
+
+# Manually log in through the visible browser window
+# Then run commands on authenticated pages
+
+node navigate.js --url=https://app.example.com/dashboard
+node screenshot.js --output ./dashboard.png
+node evaluate.js --script "document.querySelector('.user-name').textContent"
+```
+
+### Multi-Step Workflows
+```bash
+# Launch browser
+node launch-persistent.js --headless=false
+
+# Fill out multi-page form
+node navigate.js --url=https://example.com/signup
+node fill.js --selector "#email" --value "user@example.com"
+node click.js --selector ".next-button"
+# Wait for page to load, then continue...
+node fill.js --selector "#password" --value "secret123"
+node click.js --selector ".submit-button"
+```
+
+### Accessibility Audits on Live Pages
+```bash
+# Launch and navigate manually to complex authenticated state
+node launch-persistent.js --headless=false
+
+# After manual navigation/interaction, run audits
+node evaluate.js --script "/* accessibility check script */"
+node screenshot.js --output ./audit.png
+```
+
+## Advantages
+
+- **Manual interaction**: Log in, navigate, or manipulate the page manually
+- **Persistent state**: Cookies, localStorage, and session state preserved
+- **Faster iterations**: No browser startup delay for each command
+- **Real-world testing**: Test on actual authenticated or complex application states
+
+## Backwards Compatibility
+
+All existing scripts work exactly as before if no persistent browser is running. The enhancement is completely opt-in.

--- a/.claude/skills/chrome-devtools/scripts/close-persistent.js
+++ b/.claude/skills/chrome-devtools/scripts/close-persistent.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Close the persistent Chrome browser
+ */
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ENDPOINT_FILE = path.join(__dirname, '.browser-endpoint');
+
+async function main() {
+  if (!fs.existsSync(ENDPOINT_FILE)) {
+    console.log('No persistent browser found.');
+    process.exit(0);
+  }
+
+  const wsEndpoint = fs.readFileSync(ENDPOINT_FILE, 'utf8');
+  console.log('Connecting to browser...');
+
+  try {
+    const browser = await puppeteer.connect({ browserWSEndpoint: wsEndpoint });
+    await browser.close();
+    fs.unlinkSync(ENDPOINT_FILE);
+    console.log('✓ Browser closed successfully.');
+  } catch (error) {
+    console.error('Error closing browser:', error.message);
+    // Clean up stale endpoint file
+    if (fs.existsSync(ENDPOINT_FILE)) {
+      fs.unlinkSync(ENDPOINT_FILE);
+    }
+  }
+}
+
+main();

--- a/.claude/skills/chrome-devtools/scripts/launch-persistent.js
+++ b/.claude/skills/chrome-devtools/scripts/launch-persistent.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Launch a persistent Chrome browser that can be reused across multiple commands
+ * Saves the WebSocket endpoint to a file for other scripts to connect to
+ */
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ENDPOINT_FILE = path.join(__dirname, '.browser-endpoint');
+
+async function main() {
+  // Parse command line arguments
+  const args = process.argv.slice(2);
+  const headless = !args.includes('--headless=false') && !args.includes('--no-headless');
+  const url = args.find(arg => arg.startsWith('--url='))?.split('=')[1] || 'about:blank';
+
+  console.log('Launching persistent Chrome browser...');
+
+  const browser = await puppeteer.launch({
+    headless,
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--remote-debugging-port=9222'
+    ],
+    defaultViewport: {
+      width: 1920,
+      height: 1080
+    }
+  });
+
+  const wsEndpoint = browser.wsEndpoint();
+  
+  // Save endpoint to file
+  fs.writeFileSync(ENDPOINT_FILE, wsEndpoint);
+  console.log(`Browser launched. WebSocket endpoint saved to: ${ENDPOINT_FILE}`);
+  console.log(`WebSocket: ${wsEndpoint}`);
+  
+  // Navigate to initial URL if provided
+  if (url !== 'about:blank') {
+    const page = (await browser.pages())[0];
+    console.log(`Navigating to: ${url}`);
+    await page.goto(url, { waitUntil: 'networkidle2' });
+  }
+
+  console.log('\n✓ Browser is ready for commands!');
+  console.log('  Use other scripts normally - they will connect to this browser.');
+  console.log('  Run "node close-persistent.js" or press Ctrl+C to close.\n');
+
+  // Keep process alive
+  process.on('SIGINT', async () => {
+    console.log('\nClosing browser...');
+    await browser.close();
+    if (fs.existsSync(ENDPOINT_FILE)) {
+      fs.unlinkSync(ENDPOINT_FILE);
+    }
+    process.exit(0);
+  });
+
+  // Keep alive indefinitely
+  await new Promise(() => {});
+}
+
+main().catch(error => {
+  console.error('Error launching browser:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
The present browser logic expects the skill to launch the browser each time. This change allows the use case where the user might ask Claude to launch the browser to a specific page and wait for the user to authenticate or otherwise get the desired page to a specific state. Then the user can ask followup questions to the agent to interact with the persisted browser session.